### PR TITLE
Correct prop name in example

### DIFF
--- a/docs/basics/howdoi.md
+++ b/docs/basics/howdoi.md
@@ -234,7 +234,7 @@ In particular your clip will display differently in vs-preview, even though the 
 
 === "Vanilla VS"
     ```py3
-    clip_retagged = clip.std.SetFrameProps(_Matrix=vs.MATRIX_BT601, _Range=vs.RANGE_FULL)
+    clip_retagged = clip.std.SetFrameProps(_Matrix=vs.MATRIX_BT601, _ColorRange=vs.RANGE_FULL)
     ```
 
 ### How do I convert a clip's color matrix/color range/etc?


### PR DESCRIPTION
The [reserved frame property](https://www.vapoursynth.com/doc/apireference.html#reserved-frame-properties) is `_ColorRange` not `_Range`.